### PR TITLE
Return full stripe token

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ var card = {
   currency: 'CAD' // Three-letter ISO currency code (optional)
 };
 
-function onSuccess(tokenId) {
-    console.log('Got card token!', tokenId);
+function onSuccess(token) {
+    console.log('Got card token!', token);
 }
 
 function onError(errorMessage) {

--- a/src/android/CordovaStripe.java
+++ b/src/android/CordovaStripe.java
@@ -85,7 +85,7 @@ public class CordovaStripe extends CordovaPlugin {
         cardObject,
         new TokenCallback() {
           public void onSuccess(Token token) {
-            callbackContext.success(token);
+            callbackContext.success(getCardObjectFromToken(token));
           }
           public void onError(Exception error) {
             callbackContext.error(error.getMessage());
@@ -125,7 +125,7 @@ public class CordovaStripe extends CordovaPlugin {
         bankAccountObject,
         new TokenCallback() {
           public void onSuccess(Token token) {
-            callbackContext.success(token);
+            callbackContext.success(getBankObjectFromToken(token));
           }
           public void onError(Exception error) {
             callbackContext.error(error.getMessage());
@@ -168,6 +168,58 @@ public class CordovaStripe extends CordovaPlugin {
   private void getCardType(final String cardNumber, final CallbackContext callbackContext) {
     Card card = new Card(cardNumber, null, null, null);
     callbackContext.success(card.getBrand());
+  }
+
+  private JSONObject getBankObjectFromToken(final Token token) {
+    JSONObject tokenObject = new JSONObject();
+    JSONObject bankObject = new JSONObject();
+
+    BankAccount account = token.getBankAccount();
+
+    bankObject.put('account_holder_name', account.getAccountHolderName());
+    bankObject.put('account_holder_type', account.getAccountHolderType());
+    bankObject.put('bank_name', account.getBankName());
+    bankObject.put('country', account.getCountryCode());
+    bankObject.put('currency', account.getCurrency());
+    bankObject.put('last4', account.getLast4());
+    bankObject.put('name', account.name);
+    bankObject.put('routing_number', account.getRoutingNumber());
+
+    tokenObject.put('id', token.id);
+    tokenObject.put('created', token.getCreated());
+    tokenObject.put('type', token.type);
+
+    return tokenObject;
+  }
+
+  private JSONObject getCardObjectFromToken(final Token token) {
+    JSONObject tokenObject = new JSONObject();
+    JSONObject cardObject = new JSONObject();
+
+    Card card = token.getCard();
+
+    cardObject.put('address_city', card.getAddressCity());
+    cardObject.put('address_country', card.getAddressCountry());
+    cardObject.put('address_state', card.getAddressState());
+    cardObject.put('address_line1', card.getAddressLine1());
+    cardObject.put('address_line2', card.getAddressLine2());
+    cardObject.put('address_zip', card.getAddressZip());
+    cardObject.put('brand', card.getBrand());
+    cardObject.put('country', card.getRoutingNumber());
+    cardObject.put('cvc', card.getCVC());
+    cardObject.put('exp_month', card.getExpMonth());
+    cardObject.put('exp_year', card.getExpYear());
+    cardObject.put('funding', card.getFunding());
+    cardObject.put('id', card.getId());
+    cardObject.put('last4', card.getLast4());
+    cardObject.put('name', card.getName());
+
+
+    tokenObject.put('id', token.id);
+    tokenObject.put('created', token.getCreated());
+    tokenObject.put('type', token.type);
+
+    return tokenObject;
   }
 
 }

--- a/src/android/CordovaStripe.java
+++ b/src/android/CordovaStripe.java
@@ -185,6 +185,7 @@ public class CordovaStripe extends CordovaPlugin {
     bankObject.put('name', account.name);
     bankObject.put('routing_number', account.getRoutingNumber());
 
+    tokenObject.put('bank_account', bankObject);
     tokenObject.put('id', token.id);
     tokenObject.put('created', token.getCreated());
     tokenObject.put('type', token.type);
@@ -214,7 +215,7 @@ public class CordovaStripe extends CordovaPlugin {
     cardObject.put('last4', card.getLast4());
     cardObject.put('name', card.getName());
 
-
+    tokenObject.put('card', cardObject);
     tokenObject.put('id', token.id);
     tokenObject.put('created', token.getCreated());
     tokenObject.put('type', token.type);

--- a/src/android/CordovaStripe.java
+++ b/src/android/CordovaStripe.java
@@ -85,7 +85,7 @@ public class CordovaStripe extends CordovaPlugin {
         cardObject,
         new TokenCallback() {
           public void onSuccess(Token token) {
-            callbackContext.success(token.getId());
+            callbackContext.success(token);
           }
           public void onError(Exception error) {
             callbackContext.error(error.getMessage());
@@ -125,7 +125,7 @@ public class CordovaStripe extends CordovaPlugin {
         bankAccountObject,
         new TokenCallback() {
           public void onSuccess(Token token) {
-            callbackContext.success(token.getId());
+            callbackContext.success(token);
           }
           public void onError(Exception error) {
             callbackContext.error(error.getMessage());

--- a/src/android/CordovaStripe.java
+++ b/src/android/CordovaStripe.java
@@ -176,19 +176,19 @@ public class CordovaStripe extends CordovaPlugin {
 
     BankAccount account = token.getBankAccount();
 
-    bankObject.put('account_holder_name', account.getAccountHolderName());
-    bankObject.put('account_holder_type', account.getAccountHolderType());
-    bankObject.put('bank_name', account.getBankName());
-    bankObject.put('country', account.getCountryCode());
-    bankObject.put('currency', account.getCurrency());
-    bankObject.put('last4', account.getLast4());
-    bankObject.put('name', account.name);
-    bankObject.put('routing_number', account.getRoutingNumber());
+    bankObject.put("account_holder_name", account.getAccountHolderName());
+    bankObject.put("account_holder_type", account.getAccountHolderType());
+    bankObject.put("bank_name", account.getBankName());
+    bankObject.put("country", account.getCountryCode());
+    bankObject.put("currency", account.getCurrency());
+    bankObject.put("last4", account.getLast4());
+    bankObject.put("name", account.name);
+    bankObject.put("routing_number", account.getRoutingNumber());
 
-    tokenObject.put('bank_account', bankObject);
-    tokenObject.put('id', token.id);
-    tokenObject.put('created', token.getCreated());
-    tokenObject.put('type', token.type);
+    tokenObject.put("bank_account", bankObject);
+    tokenObject.put("id", token.id);
+    tokenObject.put("created", token.getCreated());
+    tokenObject.put("type", token.type);
 
     return tokenObject;
   }
@@ -199,26 +199,26 @@ public class CordovaStripe extends CordovaPlugin {
 
     Card card = token.getCard();
 
-    cardObject.put('address_city', card.getAddressCity());
-    cardObject.put('address_country', card.getAddressCountry());
-    cardObject.put('address_state', card.getAddressState());
-    cardObject.put('address_line1', card.getAddressLine1());
-    cardObject.put('address_line2', card.getAddressLine2());
-    cardObject.put('address_zip', card.getAddressZip());
-    cardObject.put('brand', card.getBrand());
-    cardObject.put('country', card.getRoutingNumber());
-    cardObject.put('cvc', card.getCVC());
-    cardObject.put('exp_month', card.getExpMonth());
-    cardObject.put('exp_year', card.getExpYear());
-    cardObject.put('funding', card.getFunding());
-    cardObject.put('id', card.getId());
-    cardObject.put('last4', card.getLast4());
-    cardObject.put('name', card.getName());
+    cardObject.put("address_city", card.getAddressCity());
+    cardObject.put("address_country", card.getAddressCountry());
+    cardObject.put("address_state", card.getAddressState());
+    cardObject.put("address_line1", card.getAddressLine1());
+    cardObject.put("address_line2", card.getAddressLine2());
+    cardObject.put("address_zip", card.getAddressZip());
+    cardObject.put("brand", card.getBrand());
+    cardObject.put("country", card.getRoutingNumber());
+    cardObject.put("cvc", card.getCVC());
+    cardObject.put("exp_month", card.getExpMonth());
+    cardObject.put("exp_year", card.getExpYear());
+    cardObject.put("funding", card.getFunding());
+    cardObject.put("id", card.getId());
+    cardObject.put("last4", card.getLast4());
+    cardObject.put("name", card.getName());
 
-    tokenObject.put('card', cardObject);
-    tokenObject.put('id', token.id);
-    tokenObject.put('created', token.getCreated());
-    tokenObject.put('type', token.type);
+    tokenObject.put("card", cardObject);
+    tokenObject.put("id", token.id);
+    tokenObject.put("created", token.getCreated());
+    tokenObject.put("type", token.type);
 
     return tokenObject;
   }

--- a/src/android/CordovaStripe.java
+++ b/src/android/CordovaStripe.java
@@ -210,7 +210,6 @@ public class CordovaStripe extends CordovaPlugin {
     cardObject.put("exp_month", card.getExpMonth());
     cardObject.put("exp_year", card.getExpYear());
     cardObject.put("funding", card.getFunding());
-    cardObject.put("id", card.getId());
     cardObject.put("last4", card.getLast4());
     cardObject.put("name", card.getName());
 

--- a/src/android/CordovaStripe.java
+++ b/src/android/CordovaStripe.java
@@ -182,13 +182,12 @@ public class CordovaStripe extends CordovaPlugin {
     bankObject.put("country", account.getCountryCode());
     bankObject.put("currency", account.getCurrency());
     bankObject.put("last4", account.getLast4());
-    bankObject.put("name", account.name);
     bankObject.put("routing_number", account.getRoutingNumber());
 
     tokenObject.put("bank_account", bankObject);
-    tokenObject.put("id", token.id);
+    tokenObject.put("id", token.getId());
     tokenObject.put("created", token.getCreated());
-    tokenObject.put("type", token.type);
+    tokenObject.put("type", token.getType());
 
     return tokenObject;
   }
@@ -206,7 +205,7 @@ public class CordovaStripe extends CordovaPlugin {
     cardObject.put("address_line2", card.getAddressLine2());
     cardObject.put("address_zip", card.getAddressZip());
     cardObject.put("brand", card.getBrand());
-    cardObject.put("country", card.getRoutingNumber());
+    cardObject.put("country", card.getAddressCountry());
     cardObject.put("cvc", card.getCVC());
     cardObject.put("exp_month", card.getExpMonth());
     cardObject.put("exp_year", card.getExpYear());
@@ -216,9 +215,9 @@ public class CordovaStripe extends CordovaPlugin {
     cardObject.put("name", card.getName());
 
     tokenObject.put("card", cardObject);
-    tokenObject.put("id", token.id);
+    tokenObject.put("id", token.getId());
     tokenObject.put("created", token.getCreated());
-    tokenObject.put("type", token.type);
+    tokenObject.put("type", token.getType());
 
     return tokenObject;
   }

--- a/src/browser/CordovaStripe.js
+++ b/src/browser/CordovaStripe.js
@@ -20,7 +20,7 @@ var stripe = {
                 if(response.error){
                     errorCallback(response.error);
                 } else {
-                    successCallback(response.id);
+                    successCallback(response);
                 }
             });
         } catch (error) {
@@ -33,7 +33,7 @@ var stripe = {
             if(response.error){
                 errorCallback(response.error);
             } else {
-                successCallback(response.id);
+                successCallback(response);
             }
         });
     },

--- a/src/ios/CordovaStripe.m
+++ b/src/ios/CordovaStripe.m
@@ -34,7 +34,7 @@
         if (error != nil) {
             result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: error.localizedDescription];
         } else {
-            result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:token.tokenId];
+            result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK STPToken:token];
         }
         [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
     };


### PR DESCRIPTION
## Description

When adding either a card or bank account, it's useful to have the entire token object returned instead of the ID. This prevents having to make additional calls for information you already have. The way the responses are setup currently, after having added a card you immediately need to make a request to get the card type.

In the same manner, after having added banking information, you don't have the institution name. 

This PR simply returns full token objects instead of the ID associated with the token, cutting down on the number of requests needing to be made to get full information about the card and banking information. 