### PR TITLE
Fix postal_code -> address_zip API mismatch between Native SDK and Stripe JS

### DIFF
--- a/src/browser/CordovaStripe.js
+++ b/src/browser/CordovaStripe.js
@@ -15,6 +15,7 @@ var stripe = {
     },
 
     createCardToken: function(successCallback, errorCallback, args) {
+        mapNativeToJS(args[0])
         try {
             Stripe.card.createToken(args[0], function(status, response){
                 if(response.error){
@@ -69,5 +70,22 @@ var stripe = {
 
 
 };
+
+function mapNativeToJS (arg) {
+    /**
+     * Add any other API discrepancies between Native SDK and StripJS
+     * here
+     */
+
+    /**
+     * In the Native SDK 'postal_code' is the key used to represent zip code.
+     * In StripeJS however, 'address_zip' is the key used. Map 'postal_code'
+     * to 'address_zip' here to avoid 400 (Bad Request) from Stripe's API
+     */
+    if (arg.postal_code) {
+        arg.address_zip = arg.postal_code
+        delete arg.postal_code
+    }
+}
 
 require('cordova/exec/proxy').add('CordovaStripe', stripe);


### PR DESCRIPTION
Firstly, thanks for the great plugin! 👍 

Now, There seem to be some differences in the expected fields of the object used to create a card token between the Native SDK and StripeJS.

`postal_code` is used in the native SDK, but will cause a `400 (Bad Request)` if used with StripeJS while attempting to create a card token in the browser. In lieu of `postal_code`, StripeJS expects `address_zip`.

This commit just sets up a function that can be used to map any other differences between the Native and StripeJS card token object (I don't know if there are any more), and fixes the issue with postal_code. With this, the same API can be used in the browser and on the native device.