### PR TITLE
Update documentation postal_code -> postalCode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ var card = {
   address_city: 'Toronto', // city (optional)
   address_state: 'Ontario', // state/province (optional)
   address_country: 'Canada', // country (optional)
-  postal_code: 'L5L5L5', // Postal Code / Zip Code (optional)
+  postalCode: 'L5L5L5', // Postal Code / Zip Code (optional)
   currency: 'CAD' // Three-letter ISO currency code (optional)
 };
 
@@ -219,7 +219,7 @@ Parameters to create a credit card token
 | address_city | <code>string</code> | Address line 2 |
 | address_state | <code>string</code> | State/Province |
 | address_country | <code>string</code> | Country |
-| postal_code | <code>string</code> | Postal/Zip code |
+| postalCode | <code>string</code> | Postal/Zip code |
 | currency | <code>string</code> | 3-letter code for currency |
 
 <a name="module_stripe.BankAccountTokenParams"></a>

--- a/src/browser/CordovaStripe.js
+++ b/src/browser/CordovaStripe.js
@@ -82,9 +82,9 @@ function mapNativeToJS (arg) {
    * In StripeJS however, 'address_zip' is the key used. Map 'postal_code'
    * to 'address_zip' here to avoid 400 (Bad Request) from Stripe's API
    */
-  if (arg.postal_code) {
-    arg.address_zip = arg.postal_code;
-    delete arg.postal_code;
+  if (arg.postalCode) {
+    arg.address_zip = arg.postalCode;
+    delete arg.postalCode;
   }
 }
 


### PR DESCRIPTION
Unless I am missing something, `postal_code` is not the expected field in the iOS and Android native implementations. They expect `postalCode`. See:

iOS: [Line 67](https://github.com/zyra/cordova-plugin-stripe/blob/master/src/ios/CordovaStripe.m#L67)
Android: [Line 78](https://github.com/zyra/cordova-plugin-stripe/blob/master/src/android/CordovaStripe.java#78)

This PR updates the documentation to the correct field and also fixes the browser to native mapping I added as part of https://github.com/zyra/cordova-plugin-stripe/pull/34

