### PR TITLE
Set defaultPublishableKey on STPAPIClient before paying (Fix Code=50 “No such payment_intent” when confirm payment intent)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -8,7 +8,7 @@
     </js-module>
     <js-module name="CordovaStripe" src="www/CordovaStripe.js"/>
 
-    <platform name="android" kotlin="1.3.50">
+    <platform name="android" kotlin="1.4.20">
 
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="CordovaStripe">
@@ -21,14 +21,17 @@
                     android:name="com.google.android.gms.wallet.api.enabled"
                     android:value="true"/>
         </config-file>
+        <source-file src="src/android/JSArray.java" target-dir="app/src/main/kotlin/com/zyramedia/cordova/stripe"/>
+        <source-file src="src/android/JSObject.java" target-dir="app/src/main/kotlin/com/zyramedia/cordova/stripe"/>
         <source-file src="src/android/EphKeyProvider.kt" target-dir="app/src/main/kotlin/com/zyramedia/cordova/stripe"/>
         <source-file src="src/android/Helpers.kt" target-dir="app/src/main/kotlin/com/zyramedia/cordova/stripe"/>
         <source-file src="src/android/StripePaymentMethodsListener.kt" target-dir="app/src/main/kotlin/com/zyramedia/cordova/stripe"/>
+        <source-file src="src/android/GooglePayHelper.kt" target-dir="app/src/main/kotlin/com/zyramedia/cordova/stripe"/>
         <source-file src="src/android/CordovaStripe.kt" target-dir="app/src/main/kotlin/com/zyramedia/cordova/stripe"/>
         <apply-plugin>kotlin-android</apply-plugin>
         <apply-plugin>kotlin-android-extensions</apply-plugin>
         <framework src="com.google.android.gms:play-services-wallet:18.0.0"/>
-        <framework src="com.stripe:stripe-android:12.2.0"/>
+        <framework src="com.stripe:stripe-android:16.1.1"/>
         <framework src="com.google.code.gson:gson:2.8.6"/>
         <framework src="androidx.appcompat:appcompat:1.1.0"/>
     </platform>

--- a/src/android/CordovaStripe.kt
+++ b/src/android/CordovaStripe.kt
@@ -477,7 +477,7 @@ class CordovaStripe : CordovaPlugin() {
         val clientSecret = call.getString("clientSecret")
         val saveMethod = call.getBoolean("saveMethod", false)
         val redirectUrl = call.getString("redirectUrl")
-        val stripeAccountId = call.getNullableString("stripeAccountId")
+        val stripeAccountId = call.getNullableString("stripeAccountId", null)
         val session = if(call.getString("setupFutureUsage") == "on_session")  ConfirmPaymentIntentParams.SetupFutureUsage.OnSession  else ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
         var setupFutureUsage = if(saveMethod!!) session else null
         val params: ConfirmPaymentIntentParams

--- a/src/android/CordovaStripe.kt
+++ b/src/android/CordovaStripe.kt
@@ -16,7 +16,11 @@ import org.json.JSONException
 import org.json.JSONObject
 
 class PluginCall(val data: JSONObject, private val ctx: CallbackContext) {
-    fun getString(key: String, defaultValue: String? = ""): String {
+    fun getString(key: String, defaultValue: String = ""): String {
+        return data.optString(key, defaultValue)
+    }
+
+    fun getNullableString(key: String, defaultValue: String? = ""): String?{
         return data.optString(key, defaultValue)
     }
 
@@ -472,8 +476,8 @@ class CordovaStripe : CordovaPlugin() {
 
         val clientSecret = call.getString("clientSecret")
         val saveMethod = call.getBoolean("saveMethod", false)
-        val redirectUrl = call.getString("redirectUrl", null)
-        val stripeAccountId = call.getString("stripeAccountId")
+        val redirectUrl = call.getString("redirectUrl")
+        val stripeAccountId = call.getNullableString("stripeAccountId")
         val session = if(call.getString("setupFutureUsage") == "on_session")  ConfirmPaymentIntentParams.SetupFutureUsage.OnSession  else ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
         var setupFutureUsage = if(saveMethod!!) session else null
         val params: ConfirmPaymentIntentParams

--- a/src/android/CordovaStripe.kt
+++ b/src/android/CordovaStripe.kt
@@ -3,6 +3,9 @@ package com.zyramedia.cordova.stripe
 import android.app.Activity
 import android.content.Intent
 import android.util.Log
+import ca.zyra.capacitor.stripe.GetGooglePayEnv
+import ca.zyra.capacitor.stripe.GooglePayDataReq
+import ca.zyra.capacitor.stripe.GooglePayPaymentsClient
 import com.google.android.gms.wallet.*
 import com.stripe.android.*
 import com.stripe.android.model.*
@@ -13,7 +16,7 @@ import org.json.JSONException
 import org.json.JSONObject
 
 class PluginCall(val data: JSONObject, private val ctx: CallbackContext) {
-    fun getString(key: String, defaultValue: String = ""): String {
+    fun getString(key: String, defaultValue: String? = ""): String {
         return data.optString(key, defaultValue)
     }
 
@@ -68,7 +71,7 @@ class PluginCall(val data: JSONObject, private val ctx: CallbackContext) {
     fun success() {
         ctx.success()
     }
-    
+
     fun resolve() {
         ctx.success()
     }
@@ -86,8 +89,8 @@ class CordovaStripe : CordovaPlugin() {
     private lateinit var stripeInstance: Stripe
     private lateinit var publishableKey: String
     private var isTest = true
-    private var googlePayPaymentData: PaymentData? = null
     private var customerSession: CustomerSession? = null
+    private var googlePayCallback: GooglePayCallback? = null
     private val context get() = cordova.context
     private val activity get() = cordova.activity
 
@@ -95,6 +98,10 @@ class CordovaStripe : CordovaPlugin() {
 
     fun saveCall(c: PluginCall) {
         savedCall = c
+    }
+
+    fun freeSavedCall() {
+        savedCall = null
     }
 
     override fun execute(action: String?, args: JSONArray?, callbackContext: CallbackContext?): Boolean {
@@ -114,7 +121,7 @@ class CordovaStripe : CordovaPlugin() {
         return true
     }
 
-    
+
     fun setPublishableKey(call: PluginCall) {
         try {
             val key = call.getString("key")
@@ -127,7 +134,7 @@ class CordovaStripe : CordovaPlugin() {
             stripeInstance = Stripe(context, key)
             publishableKey = key
             isTest = key.contains("test")
-
+            PaymentConfiguration.init(context, key)
             call.success()
         } catch (e: Exception) {
             call.error("unable to set publishable key: " + e.localizedMessage, e)
@@ -135,35 +142,57 @@ class CordovaStripe : CordovaPlugin() {
 
     }
 
-    
+
     fun identifyCardBrand(call: PluginCall) {
         val res = JSONObject()
         res.putOpt("brand", buildCard(call.data).build().brand)
         call.success(res)
     }
 
-    
     fun validateCardNumber(call: PluginCall) {
         val res = JSONObject()
         res.putOpt("valid", buildCard(call.data).build().validateNumber())
         call.success(res)
     }
 
-    
     fun validateExpiryDate(call: PluginCall) {
         val res = JSONObject()
         res.putOpt("valid", buildCard(call.data).build().validateExpiryDate())
         call.success(res)
     }
 
-    
     fun validateCVC(call: PluginCall) {
         val res = JSONObject()
         res.putOpt("valid", buildCard(call.data).build().validateCVC())
         call.success(res)
     }
 
-    
+    fun validateCard(call: PluginCall) {
+        if (!ensurePluginInitialized(call)) {
+            return
+        }
+
+        val card = buildCard(call.data).build()
+
+        if (!card.validateNumber()) {
+            call.error("card's number is invalid")
+            return
+        }
+        else if (!card.validateExpMonth()) {
+            call.error("expiration month is invalid")
+            return
+        }
+        else if (!card.validateExpiryDate()) {
+            call.error("expiration year is invalid")
+            return
+        }
+        else if (!card.cvc.isNullOrBlank() && !card.validateCVC()) {
+            call.error("security code is invalid")
+            return
+        }
+        call.success("success")
+    }
+
     fun createCardToken(call: PluginCall) {
         if (!ensurePluginInitialized(call)) {
             return
@@ -175,6 +204,9 @@ class CordovaStripe : CordovaPlugin() {
             call.error("invalid card information")
             return
         }
+
+        val idempotencyKey = call.getString("idempotencyKey")
+        val stripeAccountId = call.getString("stripeAccountId")
 
         val callback = object : ApiResultCallback<Token> {
             override fun onSuccess(result: Token) {
@@ -194,46 +226,61 @@ class CordovaStripe : CordovaPlugin() {
             }
         }
 
-        stripeInstance.createToken(card, callback)
+        stripeInstance.createCardToken(card, idempotencyKey, stripeAccountId, callback)
     }
 
-    
+
     fun createBankAccountToken(call: PluginCall) {
         if (!ensurePluginInitialized(call)) {
             return
         }
 
+        val accountNumber = call.getString("account_number")
+        val accountHolderName = call.getString("account_holder_name")
+        val accountHolderType = call.getString("account_holder_type")
+        val country = call.getString("country")
+        val currency = call.getString("currency")
+        val routingNumber = call.getString("routing_number")
 
-        val bankAccount = BankAccount(
-                call.getString("account_number"),
-                call.getString("country"),
-                call.getString("currency"),
-                call.getString("routing_number")
-        )
+        var stripeAccHolder = BankAccountTokenParams.Type.Individual
 
-        stripeInstance.createBankAccountToken(bankAccount, object : ApiResultCallback<Token> {
+        if (accountHolderType == "company") {
+            stripeAccHolder = BankAccountTokenParams.Type.Company
+        }
+
+        val bankAccount = BankAccountTokenParams(country, currency, accountNumber, stripeAccHolder, accountHolderName, routingNumber)
+
+        val idempotencyKey = call.getString("idempotencyKey")
+        val stripeAccountId = call.getString("stripeAccountId")
+
+        val callback = object : ApiResultCallback<Token> {
             override fun onSuccess(result: Token) {
-                val tokenJs = JSONObject()
+                val js = JSONObject()
 
                 if (result.bankAccount != null) {
                     val jsObj = bankAccountToJSON(result.bankAccount!!)
-                    tokenJs.putOpt("bankAccount", jsObj)
+                    js.putOpt("bankAccount", jsObj)
                 }
 
-                tokenJs.putOpt("id", result.id)
-                tokenJs.putOpt("created", result.created)
-                tokenJs.putOpt("type", result.type)
+                js.put("id", result.id)
+                js.put("created", result.created.getTime())
+                js.put("type", result.type)
+                js.put("object", "token")
+                js.put("livemode", result.livemode)
+                js.put("used", result.used)
 
-                call.success(tokenJs)
+                call.success(js)
             }
 
             override fun onError(e: Exception) {
                 call.error("unable to create bank account token: " + e.localizedMessage, e)
             }
-        })
+        }
+
+        stripeInstance.createBankAccountToken(bankAccount, idempotencyKey, stripeAccountId, callback)
     }
 
-    
+
     fun createSourceToken(call: PluginCall) {
         if (!ensurePluginInitialized(call)) {
             return
@@ -257,6 +304,9 @@ class CordovaStripe : CordovaPlugin() {
         val email = call.getString("email")
         val callId = call.getString("callId")
 
+        val idempotencyKey = call.getString("idempotencyKey")
+        val stripeAccountId = call.getString("stripeAccountId")
+
         when (sourceType) {
             0 -> sourceParams = SourceParams.createThreeDSecureParams(amount, currency, returnURL, card)
 
@@ -279,7 +329,7 @@ class CordovaStripe : CordovaPlugin() {
             else -> return
         }
 
-        stripeInstance.createSource(sourceParams, object : ApiResultCallback<Source> {
+        val callback = object : ApiResultCallback<Source> {
             override fun onSuccess(result: Source) {
                 val tokenJs = JSONObject()
                 tokenJs.putOpt("id", result.id)
@@ -291,44 +341,116 @@ class CordovaStripe : CordovaPlugin() {
             override fun onError(e: Exception) {
                 call.error("unable to create source token: " + e.localizedMessage, e)
             }
-        })
+        }
+
+        stripeInstance.createSource(sourceParams, idempotencyKey, stripeAccountId, callback)
     }
 
-    
+
     fun createAccountToken(call: PluginCall) {
         if (!ensurePluginInitialized(call)) {
             return
         }
 
-
         val legalEntity = call.getObject("legalEntity")
-        val businessType = call.getString("businessType")
         val tosShownAndAccepted = call.getBoolean("tosShownAndAccepted")
-        val bt = if (businessType == "company") AccountParams.BusinessType.Company else AccountParams.BusinessType.Individual
-        val params = AccountParams.createAccountParams(tosShownAndAccepted!!, bt, jsonToHashMap(legalEntity))
 
-        stripeInstance.createAccountToken(params, object : ApiResultCallback<Token> {
+        val idempotencyKey = call.getString("idempotencyKey")
+        val stripeAccountId = call.getString("stripeAccountId")
+
+        var address: Address? = null
+
+        if (legalEntity.has("address")) {
+            try {
+                val addressJson = legalEntity.getJSONObject("address")
+                address = Address.fromJson(addressJson)
+            } catch (err: JSONException) {
+                Log.w(TAG, "failed to parse address from legal entity object")
+                Log.w(TAG, err)
+                Log.w(TAG, "submitting request without an address")
+            }
+        }
+
+        var verifyFront: String? = null;
+        var verifyBack: String? = null;
+
+        if (legalEntity.has("verification")) {
+            val verifyObj = legalEntity.getJSONObject("verification")
+            verifyFront = verifyObj.getString("front")
+            verifyBack = verifyObj.getString("back")
+        }
+
+        val params: AccountParams
+        val hasVerify = verifyFront != null || verifyBack != null
+
+        when (legalEntity.getString("businessType")) {
+            "company" -> {
+                val builder = AccountParams.BusinessTypeParams.Company.Builder()
+                    .setAddress(address)
+                    .setName(legalEntity.getString("name"))
+                    .setPhone(legalEntity.getString("phone"))
+
+                if (hasVerify) {
+                    val verifyDoc = AccountParams.BusinessTypeParams.Company.Document(verifyFront, verifyBack)
+                    val verify = AccountParams.BusinessTypeParams.Company.Verification(verifyDoc)
+                    builder.setVerification(verify)
+                }
+
+                params = AccountParams.create(tosShownAndAccepted, builder.build())
+                Log.d(TAG, "preparing account params for company")
+            }
+            "individual" -> {
+                val builder = AccountParams.BusinessTypeParams.Individual.Builder()
+                    .setFirstName(legalEntity.getString("first_name"))
+                    .setLastName(legalEntity.getString("last_name"))
+                    .setEmail(legalEntity.getString("email"))
+                    .setGender(legalEntity.getString("gender"))
+                    .setIdNumber(legalEntity.getString("id_number"))
+                    .setPhone(legalEntity.getString("phone"))
+                    .setSsnLast4(legalEntity.getString("ssn_last4"))
+                    .setAddress(address)
+
+                if (hasVerify) {
+                    val verifyDoc = AccountParams.BusinessTypeParams.Individual.Document(verifyFront, verifyBack)
+                    val verify = AccountParams.BusinessTypeParams.Individual.Verification(verifyDoc)
+                    builder.setVerification(verify)
+                }
+
+                params = AccountParams.create(tosShownAndAccepted, builder.build())
+                Log.d(TAG, "preparing account params for individual")
+            }
+            else -> {
+                params = AccountParams.create(tosShownAndAccepted)
+                Log.d(TAG, "preparing account param with no no details other than acceptance")
+            }
+        }
+
+        val callback = object : ApiResultCallback<Token> {
             override fun onSuccess(result: Token) {
+                Log.d(TAG, "account token was successfully created")
                 val res = JSONObject()
                 res.putOpt("token", result.id)
                 call.success(res)
             }
 
             override fun onError(e: Exception) {
+                Log.d(TAG, "failed to create account token")
                 call.error("unable to create account token: " + e.localizedMessage, e)
             }
-        })
+        }
+
+        stripeInstance.createAccountToken(params, idempotencyKey, stripeAccountId, callback)
     }
 
-    
     fun createPiiToken(call: PluginCall) {
         if (!ensurePluginInitialized(call)) {
             return
         }
 
-
         val pii = call.getString("pii")
-        stripeInstance.createPiiToken(pii, object : ApiResultCallback<Token> {
+        val idempotencyKey = call.getString("idempotencyKey")
+        val stripeAccountId = call.getString("stripeAccountId")
+        val callback = object : ApiResultCallback<Token> {
             override fun onSuccess(result: Token) {
                 val res = JSONObject()
                 res.putOpt("id", result.id)
@@ -338,55 +460,99 @@ class CordovaStripe : CordovaPlugin() {
             override fun onError(e: Exception) {
                 call.error("unable to create pii token: " + e.localizedMessage, e)
             }
-        })
+        }
+
+        stripeInstance.createPiiToken(pii, idempotencyKey, stripeAccountId, callback)
     }
 
-    
     fun confirmPaymentIntent(call: PluginCall) {
         if (!ensurePluginInitialized(call)) {
             return
         }
 
-
         val clientSecret = call.getString("clientSecret")
         val saveMethod = call.getBoolean("saveMethod", false)
-        val redirectUrl = call.getString("redirectUrl")
-
+        val redirectUrl = call.getString("redirectUrl", null)
+        val stripeAccountId = call.getString("stripeAccountId")
+        val session = if(call.getString("setupFutureUsage") == "on_session")  ConfirmPaymentIntentParams.SetupFutureUsage.OnSession  else ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+        var setupFutureUsage = if(saveMethod!!) session else null
         val params: ConfirmPaymentIntentParams
 
-        if (call.hasOption("card")) {
-            val cb = buildCard(call.getObject("card")) // TODO fix this, we need to pass call.getObject(card)xs
-            val cardParams = cb.build().toPaymentMethodParamsCard()
-            val pmCreateParams = PaymentMethodCreateParams.create(cardParams)
-            params = ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(pmCreateParams, clientSecret, redirectUrl, saveMethod!!)
-        } else if (call.hasOption("paymentMethodId")) {
-            params = ConfirmPaymentIntentParams.createWithPaymentMethodId(call.getString("paymentMethodId"), clientSecret, redirectUrl, saveMethod!!)
-        } else if (call.hasOption("sourceId")) {
-            params = ConfirmPaymentIntentParams.createWithSourceId(call.getString("sourceId"), clientSecret, redirectUrl, saveMethod!!)
-        } else if (call.getBoolean("fromGooglePay", false)!!) {
-            try {
-                val js = googlePayPaymentData!!.toJson()
-                val gpayObj = JSONObject(js)
+        this.cordova.setActivityResultCallback(this);
 
-                googlePayPaymentData = null
+        when {
+            call.hasOption("card") -> {
+                var card = call.getObject("card")
+                var address = Address.Builder()
+                    .setLine1(card.optString("address_line1"))
+                    .setLine2(card.optString("address_line2"))
+                    .setCity(card.optString("address_city"))
+                    .setState(card.optString("address_state"))
+                    .setCountry(card.optString("address_country"))
+                    .setPostalCode(card.optString("address_zip"))
+                    .build()
+                var billing_details = PaymentMethod.BillingDetails().toBuilder()
+                    .setEmail(card.optString("email"))
+                    .setName(card.optString("name"))
+                    .setPhone(card.optString("phone"))
+                    .setAddress(address)
+                    .build()
+                val cardParams = buildCard(card)
+                    .build()
+                    .toPaymentMethodParamsCard()
+                val pmCreateParams = PaymentMethodCreateParams.create(cardParams, billing_details)
+                params = ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(pmCreateParams, clientSecret, redirectUrl, saveMethod!!, setupFutureUsage=setupFutureUsage)
+            }
 
-                val pmcp = PaymentMethodCreateParams.createFromGooglePay(gpayObj)
-                params = ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(pmcp, clientSecret, redirectUrl, saveMethod!!)
-            } catch (e: JSONException) {
-                call.error("unable to parse json: " + e.localizedMessage, e)
+            call.hasOption("paymentMethodId") -> {
+                params = ConfirmPaymentIntentParams.createWithPaymentMethodId(call.getString("paymentMethodId"), clientSecret, redirectUrl, saveMethod!!)
+            }
+
+            call.hasOption("sourceId") -> {
+                params = ConfirmPaymentIntentParams.createWithSourceId(call.getString("sourceId"), clientSecret, redirectUrl, saveMethod!!)
+            }
+
+            call.hasOption("googlePayOptions") -> {
+                val opts = call.getObject("googlePayOptions")
+                val cb = object : GooglePayCallback() {
+                    override fun onSuccess(res: PaymentData) {
+                        try {
+                            val pmParams = PaymentMethodCreateParams.createFromGooglePay(JSONObject(res.toJson()))
+                            val confirmParams = ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(pmParams, clientSecret, redirectUrl, saveMethod)
+                            stripeInstance.confirmPayment(activity, confirmParams, stripeAccountId)
+                        } catch (e: JSONException) {
+                            savedCall?.error("unable to parse json: " + e.localizedMessage, e)
+                            freeSavedCall()
+                        }
+                    }
+
+                    override fun onError(err: Exception) {
+                        savedCall?.error(err.localizedMessage, err)
+                        freeSavedCall()
+                    }
+
+                }
+                saveCall(call)
+                val optsJobject = JSObject.fromJSONObject(opts);
+                processGooglePayTx(optsJobject, cb)
                 return
             }
 
-        } else {
-            params = ConfirmPaymentIntentParams.create(clientSecret, redirectUrl)
+            call.hasOption("applePayOptions") -> {
+                call.error("ApplePay is not supported on Android")
+                return
+            }
+
+            else -> {
+                params = ConfirmPaymentIntentParams.create(clientSecret, redirectUrl)
+            }
         }
-        
-        this.cordova.setActivityResultCallback(this);
-        stripeInstance.confirmPayment(activity, params)
+
+        stripeInstance.confirmPayment(activity, params, stripeAccountId)
         saveCall(call)
     }
 
-    
+
     fun confirmSetupIntent(call: PluginCall) {
         if (!ensurePluginInitialized(call)) {
             return
@@ -413,18 +579,18 @@ class CordovaStripe : CordovaPlugin() {
                 params = ConfirmSetupIntentParams.createWithoutPaymentMethod(clientSecret, redirectUrl)
             }
         }
-        
+
         this.cordova.setActivityResultCallback(this);
         stripeInstance.confirmSetupIntent(activity, params)
         saveCall(call)
     }
 
-    
+
     fun customizePaymentAuthUI(call: PluginCall) {
         call.resolve()
     }
 
-    
+
     fun isGooglePayAvailable(call: PluginCall) {
         if (!ensurePluginInitialized(call)) {
             return
@@ -432,10 +598,10 @@ class CordovaStripe : CordovaPlugin() {
 
 
         val paymentsClient = Wallet.getPaymentsClient(
-                context,
-                Wallet.WalletOptions.Builder()
-                        .setEnvironment(if (isTest) WalletConstants.ENVIRONMENT_TEST else WalletConstants.ENVIRONMENT_PRODUCTION)
-                        .build()
+            context,
+            Wallet.WalletOptions.Builder()
+                .setEnvironment(if (isTest) WalletConstants.ENVIRONMENT_TEST else WalletConstants.ENVIRONMENT_PRODUCTION)
+                .build()
         )
 
         val allowedAuthMethods = JSONArray()
@@ -455,14 +621,14 @@ class CordovaStripe : CordovaPlugin() {
 
         val req = IsReadyToPayRequest.fromJson(isReadyToPayRequestJson.toString())
         paymentsClient.isReadyToPay(req)
-                .addOnCompleteListener { task ->
-                    val obj = JSONObject()
-                    obj.putOpt("available", task.isSuccessful)
-                    call.success(obj)
-                }
+            .addOnCompleteListener { task ->
+                val obj = JSONObject()
+                obj.putOpt("available", task.isSuccessful)
+                call.success(obj)
+            }
     }
 
-    
+
     fun startGooglePayTransaction(call: PluginCall) {
         if (!ensurePluginInitialized(call)) {
             return
@@ -475,10 +641,10 @@ class CordovaStripe : CordovaPlugin() {
         Log.d(TAG, "startGooglePayTransaction | isTest: " + (if (isTest) "TRUE" else "FALSE") + " | env: " + if (env == WalletConstants.ENVIRONMENT_TEST) "TEST" else "PROD")
 
         val paymentsClient = Wallet.getPaymentsClient(
-                context,
-                Wallet.WalletOptions.Builder()
-                        .setEnvironment(env)
-                        .build()
+            context,
+            Wallet.WalletOptions.Builder()
+                .setEnvironment(env)
+                .build()
         )
 
         try {
@@ -520,18 +686,18 @@ class CordovaStripe : CordovaPlugin() {
             val shippingAddressParams = call.getObject("shippingAddressParameters", JSONObject())
 
             val params = JSONObject()
-                    .putOpt("allowedAuthMethods", authMethods)
-                    .putOpt("allowedCardNetworks", cardNetworks)
-                    .putOpt("billingAddressRequired", billingAddressRequired)
-                    .putOpt("allowPrepaidCards", allowPrepaidCards)
-                    .putOpt("billingAddressParameters", billingAddressParams)
+                .putOpt("allowedAuthMethods", authMethods)
+                .putOpt("allowedCardNetworks", cardNetworks)
+                .putOpt("billingAddressRequired", billingAddressRequired)
+                .putOpt("allowPrepaidCards", allowPrepaidCards)
+                .putOpt("billingAddressParameters", billingAddressParams)
 
             val tokenizationSpec = GooglePayConfig(publishableKey).tokenizationSpecification
 
             val cardPaymentMethod = JSONObject()
-                    .putOpt("type", "CARD")
-                    .putOpt("parameters", params)
-                    .putOpt("tokenizationSpecification", tokenizationSpec)
+                .putOpt("type", "CARD")
+                .putOpt("parameters", params)
+                .putOpt("tokenizationSpecification", tokenizationSpec)
 
             val txInfo = JSONObject()
             txInfo.putOpt("totalPrice", totalPrice)
@@ -539,11 +705,11 @@ class CordovaStripe : CordovaPlugin() {
             txInfo.putOpt("currencyCode", currencyCode)
 
             val paymentDataReq = JSONObject()
-                    .putOpt("apiVersion", 2)
-                    .putOpt("apiVersionMinor", 0)
-                    .putOpt("allowedPaymentMethods", JSONArray().put(cardPaymentMethod))
-                    .putOpt("transactionInfo", txInfo)
-                    .putOpt("emailRequired", emailRequired)
+                .putOpt("apiVersion", 2)
+                .putOpt("apiVersionMinor", 0)
+                .putOpt("allowedPaymentMethods", JSONArray().put(cardPaymentMethod))
+                .putOpt("transactionInfo", txInfo)
+                .putOpt("emailRequired", emailRequired)
 
             if (merchantName != null) {
                 paymentDataReq.putOpt("merchantInfo", JSONObject().putOpt("merchantName", merchantName))
@@ -561,9 +727,9 @@ class CordovaStripe : CordovaPlugin() {
             val req = PaymentDataRequest.fromJson(paymentDataReqStr)
 
             AutoResolveHelper.resolveTask(
-                    paymentsClient.loadPaymentData(req),
-                    activity,
-                    LOAD_PAYMENT_DATA_REQUEST_CODE
+                paymentsClient.loadPaymentData(req),
+                activity,
+                LOAD_PAYMENT_DATA_REQUEST_CODE
             )
 
             saveCall(call)
@@ -573,7 +739,7 @@ class CordovaStripe : CordovaPlugin() {
 
     }
 
-    
+
     fun initCustomerSession(call: PluginCall) {
         if (!ensurePluginInitialized(call)) {
             return
@@ -589,7 +755,7 @@ class CordovaStripe : CordovaPlugin() {
         }
     }
 
-    
+
     fun customerPaymentMethods(call: PluginCall) {
         if (!ensurePluginInitialized(call)) {
             return
@@ -603,7 +769,7 @@ class CordovaStripe : CordovaPlugin() {
         }
 
         val l = StripePaymentMethodsListener(callback = object : PaymentMethodsCallback() {
-            override fun onSuccess(paymentMethods: MutableList<PaymentMethod>) {
+            override fun onSuccess(paymentMethods: List<PaymentMethod>) {
                 val arr = JSONArray()
 
                 for (pm in paymentMethods) {
@@ -621,9 +787,9 @@ class CordovaStripe : CordovaPlugin() {
 
                         if (c.checks != null) {
                             co.putOpt("checks", JSONObject()
-                                    .putOpt("address_line1_check", c.checks!!.addressLine1Check)
-                                    .putOpt("address_postal_code_check", c.checks!!.addressPostalCodeCheck)
-                                    .putOpt("cvc_check", c.checks!!.cvcCheck)
+                                .putOpt("address_line1_check", c.checks!!.addressLine1Check)
+                                .putOpt("address_postal_code_check", c.checks!!.addressPostalCodeCheck)
+                                .putOpt("cvc_check", c.checks!!.cvcCheck)
                             )
                         }
 
@@ -656,7 +822,7 @@ class CordovaStripe : CordovaPlugin() {
         cs.getPaymentMethods(PaymentMethod.Type.Card, l)
     }
 
-    
+
     fun setCustomerDefaultSource(call: PluginCall) {
         if (customerSession == null) {
             call.error("you must call initCustomerSession first")
@@ -682,7 +848,7 @@ class CordovaStripe : CordovaPlugin() {
         })
     }
 
-    
+
     fun addCustomerSource(call: PluginCall) {
         if (customerSession == null) {
             call.error("you must call initCustomerSession first")
@@ -708,7 +874,7 @@ class CordovaStripe : CordovaPlugin() {
         })
     }
 
-    
+
     fun deleteCustomerSource(call: PluginCall) {
         if (customerSession == null) {
             call.error("you must call initCustomerSession first")
@@ -751,50 +917,42 @@ class CordovaStripe : CordovaPlugin() {
 
     private fun handleGooglePayActivityResult(resultCode: Int, data: Intent?) {
         Log.v(TAG, "handleGooglePayActivityResult called with resultCode: $resultCode")
-        val googlePayCall = savedCall
 
-        if (googlePayCall == null) {
-            Log.e(TAG, "no saved PluginCall was found")
+        if (googlePayCallback == null) {
+            Log.e(TAG, "GooglePay :: got a result but there is no callback saved")
             return
         }
+
+        val cb = googlePayCallback!!
+        googlePayCallback = null
 
         when (resultCode) {
             Activity.RESULT_OK -> {
                 if (data == null) {
-                    googlePayCall.error("an unexpected error occurred")
-                    Log.e(TAG, "data is null")
+                    Log.e(TAG, "GooglePay :: result was ok but data was null")
+                    cb.onError(Exception("unexpected error occurred"))
                     return
                 }
 
                 val paymentData = PaymentData.getFromIntent(data)
 
                 if (paymentData == null) {
-                    Log.e(TAG, "paymentData is null")
-                    googlePayCall.error("an unexpected error occurred")
+                    Log.e(TAG, "GooglePay :: result was ok but PaymentData was null")
+                    cb.onError(Exception("unexpected error occurred"))
                     return
                 }
 
-                googlePayPaymentData = paymentData
-
-                googlePayCall.resolve()
+                cb.onSuccess(paymentData)
             }
 
             Activity.RESULT_CANCELED, AutoResolveHelper.RESULT_ERROR -> {
                 val status = AutoResolveHelper.getStatusFromIntent(data)
-                val obj = JSONObject()
 
                 if (status != null) {
-                    obj.putOpt("canceled", status.isCanceled)
-                    obj.putOpt("interrupted", status.isInterrupted)
-                    obj.putOpt("success", status.isSuccess)
-                    obj.putOpt("code", status.statusCode)
-                    obj.putOpt("message", status.statusMessage)
-                    obj.putOpt("resolution", status.resolution)
+                    cb.onError(Exception(status.statusMessage))
                 } else {
-                    obj.putOpt("canceled", true)
+                    cb.onError(Exception("transaction was cancelled"))
                 }
-
-                googlePayCall.success(obj)
             }
         }
     }
@@ -846,5 +1004,34 @@ class CordovaStripe : CordovaPlugin() {
                 call.error("unable to complete transaction: " + e.localizedMessage, e)
             }
         })
+    }
+
+    private fun processGooglePayTx(opts: JSObject, callback: GooglePayCallback) {
+        val env = GetGooglePayEnv(isTest)
+
+        Log.d(TAG, "initGooglePay :: [Testing = $isTest] :: [ENV = $env]")
+
+        val paymentsClient = GooglePayPaymentsClient(context, env)
+
+        try {
+            val paymentDataReq = GooglePayDataReq(publishableKey, opts)
+
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "initGooglePay :: [payment data = $paymentDataReq]")
+            }
+
+            val req = PaymentDataRequest.fromJson(paymentDataReq)
+
+            googlePayCallback = callback
+
+            AutoResolveHelper.resolveTask(
+                paymentsClient.loadPaymentData(req),
+                activity,
+                LOAD_PAYMENT_DATA_REQUEST_CODE
+            )
+        } catch (e: JSONException) {
+            Log.e(TAG, "Failed to parse json object", e)
+            callback.onError(e)
+        }
     }
 }

--- a/src/android/GooglePayHelper.kt
+++ b/src/android/GooglePayHelper.kt
@@ -1,0 +1,127 @@
+package ca.zyra.capacitor.stripe
+
+import android.content.Context
+import com.google.android.gms.wallet.IsReadyToPayRequest
+import com.google.android.gms.wallet.PaymentsClient
+import com.google.android.gms.wallet.Wallet
+import com.google.android.gms.wallet.WalletConstants
+import com.stripe.android.GooglePayConfig
+import com.zyramedia.cordova.stripe.JSArray
+import com.zyramedia.cordova.stripe.JSObject
+import org.json.JSONObject
+
+internal fun GetGooglePayEnv(isTest: Boolean): Int {
+    return if (isTest) {
+        WalletConstants.ENVIRONMENT_TEST
+    } else {
+        WalletConstants.ENVIRONMENT_PRODUCTION
+    }
+}
+
+internal fun GooglePayPaymentsClient(context: Context, env: Int): PaymentsClient {
+    return Wallet.getPaymentsClient(
+        context,
+        Wallet.WalletOptions.Builder()
+            .setEnvironment(env)
+            .build()
+    )
+}
+
+internal fun GooglePayDummyRequest(): IsReadyToPayRequest {
+    val allowedAuthMethods = JSArray()
+    allowedAuthMethods.put("PAN_ONLY")
+    allowedAuthMethods.put("CRYPTOGRAM_3DS")
+
+    val allowedCardNetworks = JSArray()
+    allowedCardNetworks.put("AMEX")
+    allowedCardNetworks.put("DISCOVER")
+    allowedCardNetworks.put("JCB")
+    allowedCardNetworks.put("MASTERCARD")
+    allowedCardNetworks.put("VISA")
+
+    val isReadyToPayRequestJson = JSObject()
+    isReadyToPayRequestJson.putOpt("allowedAuthMethods", allowedAuthMethods)
+    isReadyToPayRequestJson.putOpt("allowedCardNetworks", allowedCardNetworks)
+
+    return IsReadyToPayRequest.fromJson(isReadyToPayRequestJson.toString())
+}
+
+internal fun GooglePayCardParams(opts: JSObject): JSONObject {
+    val authMethods = opts.getJSONArray("allowedAuthMethods")
+    val cardNetworks = opts.getJSONArray("allowedCardNetworks")
+    val allowPrepaidCards = opts.getBoolean("allowPrepaidCards", true)
+    val billingAddressRequired = opts.getBoolean("billingAddressRequired", false)
+    val billingAddressParams = opts.getJSObject("billingAddressParameters", JSObject())
+
+    return JSObject()
+        .putOpt("allowedAuthMethods", authMethods)
+        .putOpt("allowedCardNetworks", cardNetworks)
+        .putOpt("allowPrepaidCards", allowPrepaidCards)
+        .putOpt("billingAddressRequired", billingAddressRequired)
+        .putOpt("billingAddressParameters", billingAddressParams)
+}
+
+internal fun GooglePayTxInfo(opts: JSObject): JSONObject {
+    val currencyCode = opts.getString("currencyCode")
+    val countryCode = opts.getString("countryCode")
+    val transactionId = opts.getString("transactionId")
+    val totalPriceStatus = opts.getString("totalPriceStatus")
+    val totalPrice = opts.getString("totalPrice")
+    val totalPriceLabel = opts.getString("totalPriceLabel")
+    val checkoutOption = opts.getString("checkoutOption")
+
+    return JSObject()
+        .putOpt("currencyCode", currencyCode)
+        .putOpt("countryCode", countryCode)
+        .putOpt("transactionId", transactionId)
+        .putOpt("totalPriceStatus", totalPriceStatus)
+        .putOpt("totalPrice", totalPrice)
+        .putOpt("totalPriceLabel", totalPriceLabel)
+        .putOpt("checkoutOption", checkoutOption)
+}
+
+internal fun GooglePayCardPaymentMethod(publishableKey: String, opts: JSObject): JSONObject {
+    val params = GooglePayCardParams(opts)
+    val tokenizationSpec = GooglePayConfig(publishableKey).tokenizationSpecification
+
+    return JSObject()
+        .putOpt("type", "CARD")
+        .putOpt("parameters", params)
+        .putOpt("tokenizationSpecification", tokenizationSpec)
+}
+
+internal fun GooglePayDataReq(publishableKey: String, opts: JSObject): String {
+    val txInfo = GooglePayTxInfo(opts)
+    val emailRequired = opts.getBoolean("emailRequired", false)
+    val merchantName = opts.getString("merchantName")
+    val cardPaymentMethod = GooglePayCardPaymentMethod(publishableKey, opts)
+
+    val req = JSObject()
+        .putOpt("apiVersion", 2)
+        .putOpt("apiVersionMinor", 0)
+        .putOpt("allowedPaymentMethods", JSArray().put(cardPaymentMethod))
+        .putOpt("transactionInfo", txInfo)
+        .putOpt("emailRequired", emailRequired)
+
+    if (merchantName != null && merchantName.isNotEmpty()) {
+        req.putOpt(
+            "merchantInfo",
+            JSObject().putOpt("merchantName", merchantName)
+        )
+    }
+
+    val shippingAddressRequired = opts.getBoolean("shippingAddressRequired", false)
+
+    if (shippingAddressRequired!!) {
+        val shippingAddressParams = opts.getJSObject(
+            "shippingAddressParameters",
+            JSObject()
+        )
+
+        req
+            .putOpt("shippingAddressRequired", true)
+            .putOpt("shippingAddressParameters", shippingAddressParams)
+    }
+
+    return req.toString()
+}

--- a/src/android/Helpers.kt
+++ b/src/android/Helpers.kt
@@ -27,6 +27,7 @@ internal fun buildCard(call: JSONObject): Card.Builder {
             .addressZip(call.optString("address_zip"))
             .country(call.optString("address_country"))
             .currency(call.optString("currency"))
+            .addressCountry(call.optString("country"))
 }
 
 internal fun cardToJSON(card: Card): JSONObject {
@@ -50,18 +51,21 @@ internal fun cardToJSON(card: Card): JSONObject {
     return cardJs
 }
 
-internal fun bankAccountToJSON(account: BankAccount): JSONObject {
-    val bankObject = JSONObject()
+internal fun bankAccountToJSON(a: BankAccount): JSONObject {
+    val obj = JSONObject()
 
-    bankObject.putOpt("account_holder_name", account.accountHolderName)
-    bankObject.putOpt("account_holder_type", account.accountHolderType)
-    bankObject.putOpt("bank_name", account.bankName)
-    bankObject.putOpt("country", account.countryCode)
-    bankObject.putOpt("currency", account.currency)
-    bankObject.putOpt("last4", account.last4)
-    bankObject.putOpt("routing_number", account.routingNumber)
+    obj.putOpt("account_holder_name", a.accountHolderName)
+    obj.putOpt("account_holder_type", a.accountHolderType)
+    obj.putOpt("bank_name", a.bankName)
+    obj.putOpt("country", a.countryCode)
+    obj.putOpt("currency", a.currency)
+    obj.putOpt("last4", a.last4)
+    obj.putOpt("routing_number", a.routingNumber)
+    obj.putOpt("id", a.id)
+    obj.putOpt("object", "bank_account")
+    obj.putOpt("status", a.status.toString())
 
-    return bankObject
+    return obj
 }
 
 internal fun setupIntentToJSON(si: SetupIntent): JSONObject {
@@ -113,4 +117,31 @@ internal fun jsonToHashMap(obj: JSONObject?): HashMap<String, Any> {
 
         false -> return HashMap()
     }
+}
+
+internal fun pmToJson(pm: PaymentMethod): JSONObject {
+    val obj = JSONObject()
+    obj.putOpt("created", pm.created)
+    obj.putOpt("customerId", pm.customerId)
+    obj.putOpt("id", pm.id)
+    obj.putOpt("livemode", pm.liveMode)
+    obj.putOpt("type", pm.type)
+
+    if (pm.card != null) {
+        val co = JSONObject()
+        val c: PaymentMethod.Card = pm.card!!
+        co.putOpt("brand", c.brand)
+        co.putOpt("country", c.country)
+        co.putOpt("exp_month", c.expiryMonth)
+        co.putOpt("exp_year", c.expiryYear)
+        co.putOpt("funding", c.funding)
+        co.putOpt("last4", c.last4)
+
+        if (c.threeDSecureUsage != null) {
+            co.put("three_d_secure_usage", JSONObject().putOpt("supported", c.threeDSecureUsage!!.isSupported))
+        }
+
+        obj.put("card", co)
+    }
+    return obj
 }

--- a/src/android/JSArray.java
+++ b/src/android/JSArray.java
@@ -1,0 +1,51 @@
+package com.zyramedia.cordova.stripe;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.json.JSONArray;
+import org.json.JSONException;
+
+public class JSArray extends JSONArray {
+
+    public JSArray() {
+        super();
+    }
+
+    public JSArray(String json) throws JSONException {
+        super(json);
+    }
+
+    public JSArray(Collection copyFrom) {
+        super(copyFrom);
+    }
+
+    public JSArray(Object array) throws JSONException {
+        super(array);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <E> List<E> toList() throws JSONException {
+        List<E> items = new ArrayList<>();
+        Object o = null;
+        for (int i = 0; i < this.length(); i++) {
+            o = this.get(i);
+            try {
+                items.add((E) this.get(i));
+            } catch (Exception ex) {
+                throw new JSONException("Not all items are instances of the given type");
+            }
+        }
+        return items;
+    }
+
+    /**
+     * Create a new JSArray without throwing a error
+     */
+    public static JSArray from(Object array) {
+        try {
+            return new JSArray(array);
+        } catch (JSONException ex) {}
+        return null;
+    }
+}

--- a/src/android/JSObject.java
+++ b/src/android/JSObject.java
@@ -1,0 +1,164 @@
+package com.zyramedia.cordova.stripe;
+
+import androidx.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * A wrapper around JSONObject that isn't afraid to do simple
+ * JSON put operations without having to throw an exception
+ * for every little thing jeez
+ */
+public class JSObject extends JSONObject {
+
+    public JSObject() {
+        super();
+    }
+
+    public JSObject(String json) throws JSONException {
+        super(json);
+    }
+
+    public JSObject(JSONObject obj, String[] names) throws JSONException {
+        super(obj, names);
+    }
+
+    /**
+     * Convert a pathetic JSONObject into a JSObject
+     * @param obj
+     */
+    public static JSObject fromJSONObject(JSONObject obj) throws JSONException {
+        Iterator<String> keysIter = obj.keys();
+        List<String> keys = new ArrayList<>();
+        while (keysIter.hasNext()) {
+            keys.add(keysIter.next());
+        }
+
+        return new JSObject(obj, keys.toArray(new String[keys.size()]));
+    }
+
+    @Override
+    @Nullable
+    public String getString(String key) {
+        return getString(key, null);
+    }
+
+    @Nullable
+    public String getString(String key, @Nullable String defaultValue) {
+        try {
+            String value = super.getString(key);
+            if (!super.isNull(key)) {
+                return value;
+            }
+        } catch (JSONException ex) {}
+        return defaultValue;
+    }
+
+    @Nullable
+    public Integer getInteger(String key) {
+        return getInteger(key, null);
+    }
+
+    @Nullable
+    public Integer getInteger(String key, @Nullable Integer defaultValue) {
+        try {
+            return super.getInt(key);
+        } catch (JSONException e) {}
+        return defaultValue;
+    }
+
+    @Nullable
+    public Boolean getBoolean(String key, @Nullable Boolean defaultValue) {
+        try {
+            return super.getBoolean(key);
+        } catch (JSONException e) {}
+        return defaultValue;
+    }
+
+    /**
+     * Fetch boolean from jsonObject
+     */
+    @Nullable
+    public Boolean getBool(String key) {
+        return getBoolean(key, null);
+    }
+
+    @Nullable
+    public JSObject getJSObject(String name) {
+        try {
+            return getJSObject(name, null);
+        } catch (JSONException e) {}
+        return null;
+    }
+
+    @Nullable
+    public JSObject getJSObject(String name, @Nullable JSObject defaultValue) throws JSONException {
+        try {
+            Object obj = get(name);
+            if (obj instanceof JSONObject) {
+                Iterator<String> keysIter = ((JSONObject) obj).keys();
+                List<String> keys = new ArrayList<>();
+                while (keysIter.hasNext()) {
+                    keys.add(keysIter.next());
+                }
+
+                return new JSObject((JSONObject) obj, keys.toArray(new String[keys.size()]));
+            }
+        } catch (JSONException ex) {}
+        return defaultValue;
+    }
+
+    @Override
+    public JSObject put(String key, boolean value) {
+        try {
+            super.put(key, value);
+        } catch (JSONException ex) {}
+        return this;
+    }
+
+    @Override
+    public JSObject put(String key, int value) {
+        try {
+            super.put(key, value);
+        } catch (JSONException ex) {}
+        return this;
+    }
+
+    @Override
+    public JSObject put(String key, long value) {
+        try {
+            super.put(key, value);
+        } catch (JSONException ex) {}
+        return this;
+    }
+
+    @Override
+    public JSObject put(String key, double value) {
+        try {
+            super.put(key, value);
+        } catch (JSONException ex) {}
+        return this;
+    }
+
+    @Override
+    public JSObject put(String key, Object value) {
+        try {
+            super.put(key, value);
+        } catch (JSONException ex) {}
+        return this;
+    }
+
+    public JSObject put(String key, String value) {
+        try {
+            super.put(key, value);
+        } catch (JSONException ex) {}
+        return this;
+    }
+
+    public JSObject putSafe(String key, Object value) throws JSONException {
+        return (JSObject) super.put(key, value);
+    }
+}

--- a/src/android/StripePaymentMethodsListener.kt
+++ b/src/android/StripePaymentMethodsListener.kt
@@ -1,21 +1,26 @@
 package com.zyramedia.cordova.stripe
 
+import com.google.android.gms.wallet.PaymentData
 import com.stripe.android.CustomerSession
 import com.stripe.android.StripeError
 import com.stripe.android.model.PaymentMethod
 
 internal abstract class PaymentMethodsCallback {
-    abstract fun onSuccess(paymentMethods: MutableList<PaymentMethod>)
+    abstract fun onSuccess(paymentMethods: List<PaymentMethod>)
+    abstract fun onError(err: Exception)
+}
+
+internal abstract class GooglePayCallback {
+    abstract fun onSuccess(res: PaymentData)
     abstract fun onError(err: Exception)
 }
 
 internal class StripePaymentMethodsListener(private val callback: PaymentMethodsCallback) : CustomerSession.PaymentMethodsRetrievalListener {
-    override fun onPaymentMethodsRetrieved(paymentMethods: MutableList<PaymentMethod>) {
-        callback.onSuccess(paymentMethods)
-    }
-
     override fun onError(errorCode: Int, errorMessage: String, stripeError: StripeError?) {
         callback.onError(java.lang.Exception(errorMessage))
     }
-}
 
+    override fun onPaymentMethodsRetrieved(paymentMethods: List<PaymentMethod>) {
+        callback.onSuccess(paymentMethods)
+    }
+}

--- a/src/android/StripePaymentSessionListener.kt
+++ b/src/android/StripePaymentSessionListener.kt
@@ -1,8 +1,11 @@
 package com.zyramedia.cordova.stripe
 
 import android.util.Log
+import com.stripe.android.CustomerSession
 import com.stripe.android.PaymentSession
 import com.stripe.android.PaymentSessionData
+import com.stripe.android.StripeError
+import com.stripe.android.model.PaymentMethod
 
 internal class StripePaymentSessionListener : PaymentSession.PaymentSessionListener {
     override fun onError(errorCode: Int, errorMessage: String) {

--- a/src/ios/CordovaStripe.swift
+++ b/src/ios/CordovaStripe.swift
@@ -384,6 +384,7 @@ public class CordovaStripe: CDVPlugin {
         }
 
         let pm = STPPaymentHandler.shared()
+        STPAPIClient.shared.publishableKey = StripeAPI.defaultPublishableKey
         pm.confirmPayment(pip, with: self) { (status, pi, err) in
             switch status {
             case .failed:

--- a/src/ios/CordovaStripe.swift
+++ b/src/ios/CordovaStripe.swift
@@ -82,18 +82,19 @@ public class CordovaStripe: CDVPlugin {
                 validatingCardBrand: false
         )
         let stateExpDate = STPCardValidator.validationState(
-                forExpirationYear: call.getString("exp_year") ?? "",
-                inMonth: call.getString("exp_month") ?? ""
+            forExpirationYear: (call.getInt("exp_year") != nil) ? String(call.getInt("exp_year")!) : "",
+            inMonth: (call.getInt("exp_month") != nil) ? String(call.getInt("exp_month")!) : ""
         )
         let stateCvc = STPCardValidator.validationState(
-                forCVC: (call.getString("cvc")) ?? "",
-                cardBrand: strToBrand(call.getString("brand"))
+                forCVC: call.getString("cvc") ?? "",
+                cardBrand: STPCardValidator.brand(forNumber: call.getString("number") ?? "")
         )
         
         var pluginResult: CDVPluginResult = CDVPluginResult(
                 status: CDVCommandStatus_OK, 
                 messageAs: "success"
-            )
+        )
+        
         if (stateNumber != STPCardValidationState.valid) {
             pluginResult = CDVPluginResult(
                 status: CDVCommandStatus_ERROR, 

--- a/src/ios/CordovaStripe.swift
+++ b/src/ios/CordovaStripe.swift
@@ -75,11 +75,8 @@ public class CordovaStripe: CDVPlugin {
     }
 
     @objc func validateCard(_ command: CDVInvokedUrlCommand) {
-        let card = parseCommand(command);
-        let pluginResult: CDVPluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: [
-            "valid": state == STPCardValidationState.valid
-        ])
-
+        let call = parseCommand(command);
+       
         let stateNumber = STPCardValidator.validationState(
                 forNumber: call.getString("number"),
                 validatingCardBrand: false
@@ -93,11 +90,10 @@ public class CordovaStripe: CDVPlugin {
                 cardBrand: strToBrand(call.getString("brand"))
         )
         
-        let pluginResult: CDVPluginResult = CDVPluginResult(
+        var pluginResult: CDVPluginResult = CDVPluginResult(
                 status: CDVCommandStatus_OK, 
                 messageAs: "success"
-        )
-
+            )
         if (stateNumber != STPCardValidationState.valid) {
             pluginResult = CDVPluginResult(
                 status: CDVCommandStatus_ERROR, 
@@ -110,12 +106,11 @@ public class CordovaStripe: CDVPlugin {
                 messageAs: "expiration date is invalid"
             )
         }
-        else if (!call.getString("cvc") && stateCvc != STPCardValidationState.valid) {
+        else if ((call.getString("cvc") != nil) && stateCvc != STPCardValidationState.valid) {
             pluginResult = CDVPluginResult(
                 status: CDVCommandStatus_ERROR, 
                 messageAs: "security code is invalid"
             )
-            call.error("security code is invalid")
             return
         }
         

--- a/src/ios/CordovaStripe.swift
+++ b/src/ios/CordovaStripe.swift
@@ -96,7 +96,8 @@ public class CordovaStripe: CDVPlugin {
         let pluginResult: CDVPluginResult = CDVPluginResult(
                 status: CDVCommandStatus_OK, 
                 messageAs: "success"
-            )
+        )
+
         if (stateNumber != STPCardValidationState.valid) {
             pluginResult = CDVPluginResult(
                 status: CDVCommandStatus_ERROR, 
@@ -109,10 +110,10 @@ public class CordovaStripe: CDVPlugin {
                 messageAs: "expiration date is invalid"
             )
         }
-        else if (!call.getString('cvc') && stateCvc != STPCardValidationState.valid) {
+        else if (!call.getString("cvc") && stateCvc != STPCardValidationState.valid) {
             pluginResult = CDVPluginResult(
                 status: CDVCommandStatus_ERROR, 
-                messageAs: "expiration date is invalid"
+                messageAs: "security code is invalid"
             )
             call.error("security code is invalid")
             return

--- a/www/CordovaStripe.d.ts
+++ b/www/CordovaStripe.d.ts
@@ -343,6 +343,7 @@ export declare namespace CordovaStripe {
         static confirmSetupIntent(opts: CordovaStripe.CommonIntentOptions): Promise<void>;
         static createAccountToken(account: CordovaStripe.AccountParams): Promise<CordovaStripe.TokenResponse>;
         static createBankAccountToken(bankAccount: CordovaStripe.BankAccountTokenRequest): Promise<CordovaStripe.BankAccountTokenResponse>;
+        static validateCard(card: CordovaStripe.CardTokenRequest): Promise<string>;
         static createCardToken(card: CordovaStripe.CardTokenRequest): Promise<CordovaStripe.CardTokenResponse>;
         static createPiiToken(opts: CordovaStripe.CreatePiiTokenOptions): Promise<CordovaStripe.TokenResponse>;
         static createSourceToken(opts: CordovaStripe.CreateSourceTokenOptions): Promise<CordovaStripe.TokenResponse>;

--- a/www/CordovaStripe.js
+++ b/www/CordovaStripe.js
@@ -64,6 +64,9 @@ var CordovaStripe;
         Plugin.createBankAccountToken = function (bankAccount) {
             return execP('createBankAccountToken', bankAccount);
         };
+        Plugin.validateCard = function (card) {
+            return execP('validateCard', card);
+        };
         Plugin.createCardToken = function (card) {
             return execP('createCardToken', card);
         };

--- a/www/CordovaStripe.ts
+++ b/www/CordovaStripe.ts
@@ -425,6 +425,10 @@ export namespace CordovaStripe {
       return execP('createBankAccountToken', bankAccount);
     }
 
+    static validateCard(card: CordovaStripe.CardTokenRequest): Promise<string> {
+      return execP('validateCard', card);
+    }
+
     static createCardToken(card: CordovaStripe.CardTokenRequest): Promise<CordovaStripe.CardTokenResponse> {
       return execP('createCardToken', card);
     }


### PR DESCRIPTION
When trying to do the following:
- Pay with Stripe Account A
- Change environment on same app instance without closing the app
- Pay with Stripe Account B

The second payment will fail because of `Fix Code=50 “No such payment_intent” when confirm payment intent`

Set defaultPublishableKey on STPAPIClient before paying in order to work correctly with more than one Stripe account in a single app (Fix Code=50 “No such payment_intent” when confirm payment intent)

Maybe this is more correct to be in the setPublishableKey() method, but I'm not sure if it will work. This works for sure. 